### PR TITLE
Allow configuring the API base path in the settings

### DIFF
--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-data-service-factory.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-data-service-factory.service.ts
@@ -37,6 +37,12 @@ export abstract class KubernetesDataServiceFactoryConfig {
    */
   'default'?: DataServiceConfig
   /**
+   * The base path for the API endpoint URLs, without trailing slash.
+   * Defaults to empty string, which is equivalent to "/", where the paths get constructed like "/api/v1/namespaces/..."
+   * @see KubernetesUrlGenerator
+   */
+  basePath?: string
+  /**
    * An override config for each entity.
    * The key must match an entity name as defined in the EntityMetadataMap given in the module.
    */

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-url-generator.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-url-generator.service.ts
@@ -1,13 +1,14 @@
-import { Injectable } from '@angular/core'
+import { Injectable, Optional } from '@angular/core'
 import { HttpMethods, KubernetesUrlGenerator, UrlGenerator } from '@ccremer/kubernetes-client/fetch'
+import { KubernetesDataServiceFactoryConfig } from './kubernetes-data-service-factory.service'
 
 @Injectable({
   providedIn: 'root',
 })
 export class KubernetesUrlGeneratorService implements UrlGenerator {
   private wrapped: KubernetesUrlGenerator
-  constructor() {
-    this.wrapped = new KubernetesUrlGenerator()
+  constructor(@Optional() config?: KubernetesDataServiceFactoryConfig) {
+    this.wrapped = new KubernetesUrlGenerator(config?.basePath ?? '')
   }
 
   buildEndpoint(


### PR DESCRIPTION
* Allows setting the base path in the factory config
* The default is/was `''` (empty string), which resorts to `/api/v1/...` or `/apis/v1/...`.

### Checklist for PR Authors

- [x] Link this PR to related issues if applicable
- [x] This PR contains a single logical change (to build a better changelog)
- [x] I have cleaned up the commit history (no useless army of tiny "Update file xyz" commits)
- [x] PR title _doesn't_ contain a categorization prefix like "[chore]" or "feat:" -> There are labels for that

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these items are not required to open a PR and can be done afterwards,
while the PR is open.
-->

### Checklist for PR Reviewers

- [x] Categorize the PR by setting a good title and adding one of the release labels (see below)

  <details>
  <summary>Labels that control the release</summary>

  * `major`: major
  * `minor`: minor
  * `patch`: patch
  * `performance`: patch
  * `skip-release`: none
  * `release`: Release after merge. Use together with a Label that doesn't immediately release, e.g. `internal`.
  * `internal`: none
  * `documentation`: none
  * `tests`: none
  * `dependencies`: none

  </details>
