### PR TITLE
Fix content-type header for PATCH requests

### DIFF
--- a/packages/kubernetes-client/src/fetch/client.ts
+++ b/packages/kubernetes-client/src/fetch/client.ts
@@ -144,7 +144,7 @@ export class FetchClient implements Client {
       body: body,
       method: method,
       headers: {
-        'Content-Type': method === 'PATCH' ? 'application/strategic-merge-patch+json' : 'application/json',
+        'Content-Type': method === 'PATCH' ? 'application/merge-patch+json' : 'application/json',
       },
     }
     const initWithAuth = this.authorizer.applyAuthorization(init)


### PR DESCRIPTION
* Fixes an error returned by Kubernetes: `the body of the request was in an unknown format - accepted media types include: application/json-patch+json, application/merge-patch+json, application/apply-patch+yaml`

### Checklist for PR Authors

- [x] Link this PR to related issues if applicable
- [x] This PR contains a single logical change (to build a better changelog)
- [x] I have cleaned up the commit history (no useless army of tiny "Update file xyz" commits)
- [x] PR title _doesn't_ contain a categorization prefix like "[chore]" or "feat:" -> There are labels for that

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these items are not required to open a PR and can be done afterwards,
while the PR is open.
-->

### Checklist for PR Reviewers

- [ ] Categorize the PR by setting a good title and adding one of the release labels (see below)

  <details>
  <summary>Labels that control the release</summary>

  * `major`: major
  * `minor`: minor
  * `patch`: patch
  * `performance`: patch
  * `skip-release`: none
  * `release`: Release after merge. Use together with a Label that doesn't immediately release, e.g. `internal`.
  * `internal`: none
  * `documentation`: none
  * `tests`: none
  * `dependencies`: none

  </details>
