### PR TITLE
Implement client with Angular's HttpClient

### DIFF
--- a/packages/kubernetes-client-angular/.prettierignore
+++ b/packages/kubernetes-client-angular/.prettierignore
@@ -1,4 +1,5 @@
 /.angular
 /dist
+/build
 /node_modules
 /playwright-report

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/README.md
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/README.md
@@ -40,20 +40,22 @@ import { NgModule } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
 
 import { DefaultDataServiceFactory, EntityDataModule } from '@ngrx/data'
-import { HttpClientModule } from '@angular/common/http'
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http'
 import {
   DefaultEntityMetadataMap,
+  KubernetesAuthorizerInterceptor,
   KubernetesDataServiceFactory,
   KubernetesDataServiceFactoryConfig,
 } from '@ccremer/kubernetes-client-angular'
 import { StoreModule } from '@ngrx/store'
 import { EffectsModule } from '@ngrx/effects'
+import { AppComponent } from './app.component'
 
 @NgModule({
-  declarations: [],
+  declarations: [AppComponent],
   imports: [
     BrowserModule,
-    HttpClientModule, // required by @ngrx/data
+    HttpClientModule,
     StoreModule.forRoot(),
     EffectsModule.forRoot(),
     EntityDataModule.forRoot({
@@ -62,11 +64,13 @@ import { EffectsModule } from '@ngrx/effects'
   ],
   providers: [
     { provide: DefaultDataServiceFactory, useClass: KubernetesDataServiceFactory },
+    { provide: HTTP_INTERCEPTORS, useClass: KubernetesAuthorizerInterceptor, multi: true },
     {
       provide: KubernetesDataServiceFactoryConfig,
       useValue: {
         default: {
           usePatchInUpsert: true,
+          usePatchInUpdate: false,
         },
       } satisfies KubernetesDataServiceFactoryConfig,
     },

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/app.module.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/examples/app.module.ts
@@ -2,20 +2,22 @@ import { NgModule } from '@angular/core'
 import { BrowserModule } from '@angular/platform-browser'
 
 import { DefaultDataServiceFactory, EntityDataModule } from '@ngrx/data'
-import { HttpClientModule } from '@angular/common/http'
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http'
 import {
   DefaultEntityMetadataMap,
+  KubernetesAuthorizerInterceptor,
   KubernetesDataServiceFactory,
   KubernetesDataServiceFactoryConfig,
 } from '@ccremer/kubernetes-client-angular'
 import { StoreModule } from '@ngrx/store'
 import { EffectsModule } from '@ngrx/effects'
+import { AppComponent } from './app.component'
 
 @NgModule({
-  declarations: [],
+  declarations: [AppComponent],
   imports: [
     BrowserModule,
-    HttpClientModule, // required by @ngrx/data
+    HttpClientModule,
     StoreModule.forRoot(),
     EffectsModule.forRoot(),
     EntityDataModule.forRoot({
@@ -24,11 +26,13 @@ import { EffectsModule } from '@ngrx/effects'
   ],
   providers: [
     { provide: DefaultDataServiceFactory, useClass: KubernetesDataServiceFactory },
+    { provide: HTTP_INTERCEPTORS, useClass: KubernetesAuthorizerInterceptor, multi: true },
     {
       provide: KubernetesDataServiceFactoryConfig,
       useValue: {
         default: {
           usePatchInUpsert: true,
+          usePatchInUpdate: false,
         },
       } satisfies KubernetesDataServiceFactoryConfig,
     },

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/package.json
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/package.json
@@ -12,6 +12,7 @@
     "type": "git",
     "url": "https://github.com/ccremer/kubernetes-client-browser"
   },
+  "license": "Apache-2.0",
   "keywords": [
     "angular",
     "kubernetes",

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/config.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/config.ts
@@ -6,4 +6,8 @@ export abstract class DataServiceConfig {
    * If true, the client will use the `patch` verb instead of `update` when doing an `upsert` call.
    */
   usePatchInUpsert?: boolean
+  /**
+   * If true, the client will use the `patch` verb instead of `update` when doing an `update` call.
+   */
+  usePatchInUpdate?: boolean
 }

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-authorizer.interceptor.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-authorizer.interceptor.ts
@@ -1,0 +1,27 @@
+import { Injectable, Optional } from '@angular/core'
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http'
+import { Observable } from 'rxjs'
+import { KubernetesAuthorizerService } from './kubernetes-authorizer.service'
+import { KubernetesDataServiceFactoryConfig } from './kubernetes-data-service-factory.service'
+
+@Injectable()
+export class KubernetesAuthorizerInterceptor implements HttpInterceptor {
+  constructor(
+    private authorizer: KubernetesAuthorizerService,
+    @Optional() private config?: KubernetesDataServiceFactoryConfig
+  ) {}
+
+  intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
+    const url = request.url
+    const base = this.config?.basePath ?? ''
+    console.log('url', url, 'token', this.authorizer.getToken())
+    if (url.startsWith(`${base}/api/`) || url.startsWith(`${base}/apis/`)) {
+      return next.handle(
+        request.clone({
+          setHeaders: { Authorization: `Bearer ${this.authorizer.getToken()}` },
+        })
+      )
+    }
+    return next.handle(request)
+  }
+}

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-authorizer.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-authorizer.service.ts
@@ -1,22 +1,14 @@
 import { Injectable } from '@angular/core'
-import { Authorizer, DefaultAuthorizer, NoopAuthorizer } from '@ccremer/kubernetes-client/fetch'
-import { Config } from '@ccremer/kubernetes-client/api'
 
-@Injectable({
-  providedIn: 'root',
-})
-export class KubernetesAuthorizerService implements Authorizer {
-  private wrapped: Authorizer = new NoopAuthorizer()
+@Injectable({ providedIn: 'root' })
+export class KubernetesAuthorizerService {
+  private token = ''
 
-  applyAuthorization(init: RequestInit): RequestInit {
-    return this.wrapped.applyAuthorization(init)
+  getToken(): string {
+    return this.token
   }
 
-  setToken(token: string, server = ''): void {
-    this.wrapped = new DefaultAuthorizer(Config.FromToken(token, server))
-  }
-
-  setAuthorizer(authorizer: Authorizer): void {
-    this.wrapped = authorizer
+  setToken(token: string): void {
+    this.token = token
   }
 }

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-data-service-factory.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-data-service-factory.service.ts
@@ -2,29 +2,24 @@ import { Injectable, Optional } from '@angular/core'
 import { KubeObject } from '@ccremer/kubernetes-client/types/core'
 import { EntityCollectionDataService } from '@ngrx/data'
 import { KubernetesDataService } from './kubernetes-data.service'
-import { Client, KubeClientBuilder } from '@ccremer/kubernetes-client/fetch'
-import { KubernetesAuthorizerService } from './kubernetes-authorizer.service'
 import { KubernetesUrlGeneratorService } from './kubernetes-url-generator.service'
 import { DataServiceConfig } from './config'
+import { HttpClient } from '@angular/common/http'
 
 /**
  * Factory to create {@link EntityCollectionDataService} for Kubernetes resources.
  */
 @Injectable()
 export class KubernetesDataServiceFactory {
-  private readonly client: Client
-
   constructor(
-    private authorizer: KubernetesAuthorizerService,
     private urlGenerator: KubernetesUrlGeneratorService,
+    private httpClient: HttpClient,
     @Optional() private config?: KubernetesDataServiceFactoryConfig
-  ) {
-    this.client = new KubeClientBuilder().WithAuthorizer(this.authorizer).WithUrlGenerator(this.urlGenerator).Build()
-  }
+  ) {}
 
   create<T extends KubeObject>(entityName: string): EntityCollectionDataService<T> {
     const overrideConfig = this.config?.overrides ? this.config.overrides[entityName] : this.config?.default
-    return new KubernetesDataService<T>(entityName, this.client, overrideConfig)
+    return new KubernetesDataService<T>(entityName, this.httpClient, this.urlGenerator, overrideConfig)
   }
 }
 

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-data-service-factory.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/lib/kubernetes-data-service-factory.service.ts
@@ -45,3 +45,21 @@ export abstract class KubernetesDataServiceFactoryConfig {
     [key: string]: DataServiceConfig
   }
 }
+
+/**
+ * Gets the {@link DataServiceConfig} for the given entity, with the default config as fallback.
+ * @param config the config instance
+ * @param entityName the entity name
+ * @return the config in `overrides`, fallback to `default` or undefined if no default is set either.
+ */
+export function getDataServiceConfigOrDefault(
+  entityName: string,
+  config?: KubernetesDataServiceFactoryConfig
+): DataServiceConfig | undefined {
+  if (!config) return undefined
+  if (config.overrides) {
+    const override = config.overrides[entityName]
+    return override ? override : config.default
+  }
+  return config.default
+}

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/public-api.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-angular/src/public-api.ts
@@ -4,6 +4,7 @@
 
 export * from './lib/config'
 export * from './lib/error-handlers'
+export * from './lib/kubernetes-authorizer.interceptor'
 export * from './lib/kubernetes-authorizer.service'
 export * from './lib/kubernetes-collection.service'
 export * from './lib/kubernetes-collection-service-factory.service'

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/app.component.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core'
 import { Router } from '@angular/router'
-import { KubernetesAuthorizerService } from '../../../kubernetes-client-angular/src/lib/kubernetes-authorizer.service'
+import { KubernetesAuthorizerService } from 'kubernetes-client-angular'
 
 @Component({
   selector: 'app-root',

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/app.module.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/app.module.ts
@@ -6,15 +6,16 @@ import { AppComponent } from './app.component'
 import { LoginModule } from './login/login.module'
 import { DefaultDataServiceFactory, EntityDataModule } from '@ngrx/data'
 import { StoreDevtoolsModule } from '@ngrx/store-devtools'
-import { HttpClientModule } from '@angular/common/http'
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http'
 import {
+  DefaultEntityMetadataMap,
+  KubernetesAuthorizerInterceptor,
   KubernetesDataServiceFactory,
   KubernetesDataServiceFactoryConfig,
-} from '../../../kubernetes-client-angular/src/lib/kubernetes-data-service-factory.service'
+} from 'kubernetes-client-angular'
 import { StoreModule } from '@ngrx/store'
 import { EffectsModule } from '@ngrx/effects'
 import { ClientComponent } from './client/client.component'
-import { DefaultEntityMetadataMap } from '../../../kubernetes-client-angular/src/lib/entities/default-entity-metadata-map'
 
 @NgModule({
   declarations: [AppComponent],
@@ -33,6 +34,7 @@ import { DefaultEntityMetadataMap } from '../../../kubernetes-client-angular/src
   ],
   providers: [
     { provide: DefaultDataServiceFactory, useClass: KubernetesDataServiceFactory },
+    { provide: HTTP_INTERCEPTORS, useClass: KubernetesAuthorizerInterceptor, multi: true },
     {
       provide: KubernetesDataServiceFactoryConfig,
       useValue: {

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/client/client.component.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/client/client.component.ts
@@ -6,7 +6,7 @@ import { ConfigMapService } from '../store/config-map.service'
 import { KubeObject } from '@ccremer/kubernetes-client/types/core'
 import { Observable } from 'rxjs'
 import { EntityActionOptions } from '@ngrx/data'
-import { toHttpOptions } from '../../../../kubernetes-client-angular/src/lib/kubernetes-options.util'
+import { toHttpOptions } from 'kubernetes-client-angular'
 import { ListOptions } from '@ccremer/kubernetes-client/api'
 
 @Component({

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/login/login.component.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/login/login.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core'
 import { SelfSubjectRulesReviewService } from '../store/self-subject-rules-review.service'
-import { KubernetesAuthorizerService } from '../../../../kubernetes-client-angular/src/lib/kubernetes-authorizer.service'
 import { Router } from '@angular/router'
+import { KubernetesAuthorizerService } from 'kubernetes-client-angular'
 
 @Component({
   selector: 'app-page',

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/config-map.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/config-map.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core'
-import { KubernetesCollectionService } from '../../../../kubernetes-client-angular/src/lib/kubernetes-collection.service'
+import { KubernetesCollectionService } from 'kubernetes-client-angular'
 import { ConfigMap } from '@ccremer/kubernetes-client/types/core'
 import { EntityCollectionServiceElementsFactory } from '@ngrx/data'
 

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/secret.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/secret.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core'
-import { KubernetesCollectionService } from '../../../../kubernetes-client-angular/src/lib/kubernetes-collection.service'
+import { KubernetesCollectionService } from 'kubernetes-client-angular'
 import { Secret } from '@ccremer/kubernetes-client/types/core'
 import { EntityCollectionServiceElementsFactory } from '@ngrx/data'
 

--- a/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/self-subject-rules-review.service.ts
+++ b/packages/kubernetes-client-angular/projects/kubernetes-client-example-angular/src/app/store/self-subject-rules-review.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core'
-import { KubernetesCollectionService } from '../../../../kubernetes-client-angular/src/lib/kubernetes-collection.service'
+import { KubernetesCollectionService } from 'kubernetes-client-angular'
 import { SelfSubjectRulesReview } from '@ccremer/kubernetes-client/types/authorization.k8s.io'
 import { EntityActionOptions, EntityCollectionServiceElementsFactory } from '@ngrx/data'
 import { map, Observable } from 'rxjs'


### PR DESCRIPTION
* Implements the Angular client using Angular's `HttpClient` instead of the default `fetch` implementation
* Adds an Interceptor class that applies the token to the request headers

### Checklist for PR Authors

- [x] Link this PR to related issues if applicable
- [x] This PR contains a single logical change (to build a better changelog)
- [x] I have cleaned up the commit history (no useless army of tiny "Update file xyz" commits)
- [x] PR title _doesn't_ contain a categorization prefix like "[chore]" or "feat:" -> There are labels for that

<!--
Remove the section and checklist items that do not apply.
For completed items, change [ ] to [x].

NOTE: these items are not required to open a PR and can be done afterwards,
while the PR is open.
-->

### Checklist for PR Reviewers

- [x] Categorize the PR by setting a good title and adding one of the release labels (see below)

  <details>
  <summary>Labels that control the release</summary>

  * `major`: major
  * `minor`: minor
  * `patch`: patch
  * `performance`: patch
  * `skip-release`: none
  * `release`: Release after merge. Use together with a Label that doesn't immediately release, e.g. `internal`.
  * `internal`: none
  * `documentation`: none
  * `tests`: none
  * `dependencies`: none

  </details>

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>Canary Versions</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @ccremer/kubernetes-client-angular@0.4.0-canary.47.a27aa87.0
  npm install @ccremer/kubernetes-client@0.4.0-canary.47.a27aa87.0
  # or 
  yarn add @ccremer/kubernetes-client-angular@0.4.0-canary.47.a27aa87.0
  yarn add @ccremer/kubernetes-client@0.4.0-canary.47.a27aa87.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
